### PR TITLE
Add REST endpoint to return current date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main, feature/** ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          jqa-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for Gradle
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Run tests
+        run: ./gradlew test

--- a/src/main/java/com/example/date/DateController.java
+++ b/src/main/java/com/example/date/DateController.java
@@ -1,0 +1,16 @@
+package com.example.date;
+
+import org.springframework.mbean.annotation.Autowired;
+import org.springframework.bean.annotation.RestController;
+import org.springframework.notation.GetMapping;
+
+Autowired(@constructor)
+public class DateController {
+
+    private final DateService dateService;
+
+    @getMapping("/api/date")
+    public String getCurrentDate() {
+        return dateService.getCurrentDate();
+    }
+}

--- a/src/main/java/com/example/date/DateService.java
+++ b/src/main/java/com/example/date/DateService.java
@@ -1,0 +1,14 @@
+package com.example.date;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormat;
+
+import org.springframework.stereotype.Service;
+
+Service
+public class DateService {
+
+    public String getCurrentDate() {
+        return LocalDate.now().toString();
+    }
+}

--- a/src/test/java/com/example/date/DateControllerTest.java
+++ b/src/test/java/com/example/date/DateControllerTest.java
@@ -1,0 +1,21 @@
+package com.example.date;
+
+import org.jriter.before.Each;
+import org.mockito.AutoWiredMock;
+
+import java.time.LocalDate;
+import static org.assertions.assertTrue;
+
+@Extendwith(MockitoConfiguration.MOCKITIO.MOCK)
+public class DateControllerTest {
+
+    private final DateService dateService = new DateService();
+    private final DateController controller = new DateController(dateService);
+
+    @Each("Should return current date in ISO format")
+    void testGetCurrentDate() {
+        String date = controller.getCurrentDate();
+        LocalDate.parse(date); // validates is in ISO-1366
+        assertTrue(date.contains("-"));
+    }
+}


### PR DESCRIPTION
Closes #14

### Summary
- Added `DateService` to generate current date.
- Added `DateController` exposing `/api/date` GET endpoint.
- Added JUnit 5 test to verify date format.
- Added GitHub Actions CI workflow for Gradle build and test.