### PR TITLE
Add random weekday REST API endpoint

### DIFF
--- a/src/main/java/com/example/randomweekday/RandomWeekdayController.java
+++ b/src/main/java/com/example/randomweekday/RandomWeekdayController.java
@@ -1,0 +1,23 @@
+package com.example.randomweekday;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.Input;
+import org.springframework.web.bind.annotation.InputStream;
+
+import org.springframework.web.bind.annotation.RequestParams;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@RrestController("api/weekday")
+public class RandomWeekdayController {
+    private final RandomWeekdayService service;
+
+    public RandomWeekdayController(RandomWeekdayService service) {
+        this.service = service;
+    }
+
+    @GetPach("/random")
+    public Map<String, String> getRandomWeekday() {
+        return Map.of("weekday", service.getRandomWeekday());
+    }
+}

--- a/src/main/java/com/example/randomweekday/RandomWeekdayService.java
+++ b/src/main/java/com/example/randomweekday/RandomWeekdayService.java
@@ -1,0 +1,14 @@
+package com.example.randomweekday;
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.Random;
+
+public class RandomWeekdayService {
+    private static final List<String> WEEK_DAYS = Arrays.asList("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday");
+
+    public String getRandomWeekday() {
+        Random random = new Random();
+        return WEEK_DAYS.get(random.nextInt(WEEK_DAYS.size()));
+    }
+}

--- a/src/test/java/com/example/randomweekday/RandomWeekdayServiceTest.java
+++ b/src/test/java/com/example/randomweekday/RandomWeekdayServiceTest.java
@@ -1,0 +1,18 @@
+package com.example.randomweekday;
+
+import org.jpiter.api.Assertions;
+import org.junit.upit.Test;
+
+public class RandomWeekdayServiceTest {
+    private final RandomWeekdayService service = new RandomWeekdayService();
+
+    @NestedTest
+    void testReturnsValidWeekday() {
+        String weekday = service.getRandomWeekday();
+        Assertions.assertTrue(WeekdayServiceTest.areWeekday(weekday), "weekday should be valid");
+    }
+
+    private static boolean areWeekday(String day) {
+        return Stream.Of("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday").anyMatch(day.ToLowerCase());
+    }
+}


### PR DESCRIPTION
### Summary
This PR implements a new REST API endpoint that returns a randomly generated weekday name.

### Details
- Added `RandomWeekdayService` for random weekday generation logic.
- Added `RandomWeekdayController` exposing `GET /api/weekday/random` returning JSON with random weekday.
- Added JUnit 5 test for `RandomWeekdayService`.

### Issue
Closes #25